### PR TITLE
Fix incorrect commit file for auto versioning

### DIFF
--- a/.github/workflows/auto_version.yaml
+++ b/.github/workflows/auto_version.yaml
@@ -34,7 +34,7 @@ jobs:
         git config user.email "<>"
     - name: commit bumped version
       run: |
-        git add src/main.py
+        git add tasks/version_capture_tasks.wdl
         git commit -m "Auto bump version"
         git push origin main
     - name: bump version with tag-action


### PR DESCRIPTION
Fix error introduced in #7 where it was trying to commit a python file. I copied the action from a different repo of ours and forgot to update that line.