### PR TITLE
Add back transfer horizon report until new coinfection parser ready

### DIFF
--- a/tasks/summary_tasks.wdl
+++ b/tasks/summary_tasks.wdl
@@ -50,6 +50,7 @@ task summarize_results {
 
     output {
         File sequencing_results_csv = "~{project_name}_sequencing_results.csv"
+        File wgs_horizon_report_csv = "~{project_name}_wgs_horizon_report.csv"
     }
 
     runtime {
@@ -65,6 +66,7 @@ task transfer_outputs {
         String out_dir
         File cat_fastas
         File sequencing_results_csv
+        File wgs_horizon_report_csv
     }
 
     String outdirpath = sub(out_dir, "/$", "")
@@ -72,6 +74,7 @@ task transfer_outputs {
     command <<<
         gsutil -m cp ~{cat_fastas} ~{outdirpath}/multifasta/
         gsutil -m cp ~{sequencing_results_csv} ~{outdirpath}/summary_results/
+        gsutil -m cp ~{wgs_horizon_report_csv} ~{outdirpath}/summary_results/
     >>>
 
     runtime {

--- a/workflows/RSV_illumina_pe_summary.wdl
+++ b/workflows/RSV_illumina_pe_summary.wdl
@@ -53,6 +53,7 @@ workflow RSV_illumina_pe_summary {
             out_dir = "~{out_dir_path}/~{workflow_version_capture.workflow_version_path}",
             cat_fastas = concatenate_consensus.cat_fastas,
             sequencing_results_csv = summarize_results.sequencing_results_csv,
+            wgs_horizon_report_csv = summarize_results.wgs_horizon_report_csv
     }
 
     output {
@@ -61,5 +62,6 @@ workflow RSV_illumina_pe_summary {
         File cat_fastas = concatenate_consensus.cat_fastas
 
         File sequencing_results_csv = summarize_results.sequencing_results_csv
+        File wgs_horizon_report_csv = summarize_results.wgs_horizon_report_csv
     }
 }


### PR DESCRIPTION
This PR:

- closes #15 

We (@danpolanco) removed the horizon report file transfer too soon.