### PR TITLE
Update concat_seq_results to use primer_set column instead of organism

### DIFF
--- a/scripts/concat_seq_results.py
+++ b/scripts/concat_seq_results.py
@@ -245,7 +245,7 @@ def make_wgs_horizon_output(
     results_df["workflow"] = args.workflow_name
     results_df["nextclade_version"] = args.nextclade_version
     results_df["workflow_version"] = args.workflow_version
-    results_df["WGS_type"] = results_df["organism"].str.split().str[1]
+    results_df["WGS_type"] = results_df["primer_set"].str.extract(r"RSV[-_]?([AB])")
     results_df["WGS_clade_nextclade"] = results_df["clade"]
     results_df["WGS_Gclade_nextclade"] = results_df["G_clade"]
     results_df["analysis_date"] = str(date.today())


### PR DESCRIPTION
This PR

- continues #14.
- continues #15.

`concat_seq_results.py` was still using `organism` to determine WGS_type. This fixes it to use `primer_set` and additionally uses a regex (i.e. `RSV[-_]?[AB]`) for flexibility.