### PR TITLE
Update nextclade to 3.10.2 to fix missing g_clade for rsv_b

### DIFF
--- a/tasks/post_assembly_tasks.wdl
+++ b/tasks/post_assembly_tasks.wdl
@@ -96,7 +96,7 @@ task call_clades_nextclade {
         String organism_id
     }
 
-    String docker = "nextstrain/nextclade:3.8.2"
+    String docker = "nextstrain/nextclade:3.10.2"
 
     command <<<
         nextclade --version | awk '/nextclade/ {print $2}' > VERSION


### PR DESCRIPTION
This PR:

- closes #23.

### Upstream Effects

None.

### Input Changes

None.

### Output Changes

Fixed missing `G_clade` for RSVB.

### Downstream Effects

None.

## Testing 🛠️

**Test dataset(s):**

- rsv_0015_nextseq

**Test(s) performed:**

- local testing.
- will perform Terra testing once merged to develop.

**Results (including if the results matched the expected results):**

- same results as previously other than `G_clade` now being fixed.