### PR TITLE
Update develop with changes from main for v0.3.0

### DIFF
--- a/tasks/version_capture_tasks.wdl
+++ b/tasks/version_capture_tasks.wdl
@@ -22,7 +22,7 @@ task workflow_version_capture {
 
     command <<<
         date +"%Y-%m-%d" > TODAY
-        echo "v0.3.0" > WORKFLOW_VERSION
+        echo "v0.4.0" > WORKFLOW_VERSION
     >>>
 
     output {


### PR DESCRIPTION
The GitHub auto version action doesn't have pushing to `develop` so it has fallen behind version number.