### PR TITLE
Mhr remove horizon output

### DIFF
--- a/scripts/concat_seq_results.py
+++ b/scripts/concat_seq_results.py
@@ -81,9 +81,9 @@ def create_list_from_write_lines_input(write_lines_input: str) -> list[str]:
 def concat_cov_out(cov_out_file_list: list[str]) -> pd.DataFrame:
     """Concatenate covergate output files."""
     # initiate dataframe for concatenation
-    print('------------------BEGIN concat_cov_out -------------')
-    print('concatenating cov out files')
-    print(f'length of cov out files: {len(cov_out_file_list)}')
+    print("------------------BEGIN concat_cov_out -------------")
+    print("concatenating cov out files")
+    print(f"length of cov out files: {len(cov_out_file_list)}")
     df = pd.DataFrame()
     sample_name_list = []
     samtools_mapped_reads_list = []
@@ -119,70 +119,69 @@ def concat_cov_out(cov_out_file_list: list[str]) -> pd.DataFrame:
     df["mean_base_quality"] = samtools_baseq_list
     df["mean_map_quality"] = samtools_mapq_list
 
-    print(f'cov out concatenated size: {df.shape}')
+    print(f"cov out concatenated size: {df.shape}")
     print()
     print(df.head)
     print()
-    print(f'# row with NAs: {df[df.isna().any(axis=1)].shape}')
+    print(f"# row with NAs: {df[df.isna().any(axis=1)].shape}")
     print(df[df.isna().any(axis=1)])
-    print('')
-    print('---------------END cov out ---------------')   
-    print('')
+    print("")
+    print("---------------END cov out ---------------")
+    print("")
 
     return df
 
 
 def concat_percent_cvg(percent_cvg_file_list: list[str]) -> pd.DataFrame:
     """Concatenate percent coverage files."""
-    print('------------------BEGIN concat_percent_cvg-------------')
-    print('concatenating percent cvg files files')
-    print(f'length of cov out files: {len(percent_cvg_file_list)}')
+    print("------------------BEGIN concat_percent_cvg-------------")
+    print("concatenating percent cvg files files")
+    print(f"length of cov out files: {len(percent_cvg_file_list)}")
 
     df_list = []
     for file in percent_cvg_file_list:
         d = pd.read_csv(file, dtype={"sample_name": object})
         df_list.append(d)
 
-    print(f'number of dataframes to concat in list: {len(df_list)}')
+    print(f"number of dataframes to concat in list: {len(df_list)}")
 
     df = pd.concat(df_list)
 
-    print(f'percent cvg concatenated size: {df.shape}')
+    print(f"percent cvg concatenated size: {df.shape}")
     print()
     print(df.head())
     print()
-    print(f'# row with NAs: {df[df.isna().any(axis=1)].shape}')
+    print(f"# row with NAs: {df[df.isna().any(axis=1)].shape}")
     print(df[df.isna().any(axis=1)])
-    print('')
-    print('---------------END perecent coverage out---------------')   
-    print('')
+    print("")
+    print("---------------END perecent coverage out---------------")
+    print("")
 
     return df
 
 
 def concat_nextclade_csv(nextclade_csv_file_list: list[str]) -> pd.DataFrame:
     """Concatenate nextclade csv files."""
-    print('------------------BEGIN concat nextclade-------------')
-    print('concatenating nextclade files')
-    print(f'length of cov out files: {len(nextclade_csv_file_list)}')
+    print("------------------BEGIN concat nextclade-------------")
+    print("concatenating nextclade files")
+    print(f"length of cov out files: {len(nextclade_csv_file_list)}")
     df_list = []
     for file in nextclade_csv_file_list:
         d = pd.read_csv(file, sep=";")
         df_list.append(d)
-    
-    print(f'number of dataframes to concat in list: {len(df_list)}')
+
+    print(f"number of dataframes to concat in list: {len(df_list)}")
     df = pd.concat(df_list)
 
-
-    print(f'nextclade concatenated size: {df.shape}')
+    print(f"nextclade concatenated size: {df.shape}")
     print()
     print(df.head())
     print()
-    print(f'# row with NAs: {df[df.isna().any(axis=1)].shape}')
+    print(f"# row with NAs: {df[df.isna().any(axis=1)].shape}")
     print(df[df.isna().any(axis=1)])
-    print('')
-    print('---------------END nextclade ---------------')   
-    print('')
+    print("")
+    print("---------------END nextclade ---------------")
+    print("")
 
     return df
 
@@ -197,7 +196,7 @@ def concat_results(
     nextclade_df: pd.DataFrame,
 ) -> pd.DataFrame:
     """Concatenate results."""
-    print('------------------BEGIN concat_results-------------')
+    print("------------------BEGIN concat_results-------------")
 
     # set some functions for getting data formatted
     def get_sample_name_from_fasta_header(fasta_header: str) -> str:
@@ -208,7 +207,7 @@ def concat_results(
         return "CO-CDPHE-%s" % sample_name
 
     # create dataframe and fill with constant strings
-    print('----------------creating base df')
+    print("----------------creating base df")
     df = pd.DataFrame()
     df["sample_name"] = sample_name_list
     df = df.set_index("sample_name")
@@ -218,78 +217,77 @@ def concat_results(
     print(df.head())
 
     # read in workbook
-    print('')
-    print('-----------------reading in wb')
+    print("")
+    print("-----------------reading in wb")
     workbook = pd.read_csv(
         workbook_path, sep="\t", dtype={"sample_name": object, "hsn": object}
     )
     workbook = workbook.set_index("sample_name")
     print(workbook.shape)
     print(workbook.head)
-    print('')
-
+    print("")
 
     # set index on the samtools_df and percent_cvg_df and variants_df to prepare for joining
-    print('----------------setting index on dfs before merging')
+    print("----------------setting index on dfs before merging")
     cov_out_df = cov_out_df.set_index("sample_name")
     percent_cvg_df = percent_cvg_df.set_index("sample_name")
     nextclade_df["sample_name"] = nextclade_df["seqName"].apply(
         get_sample_name_from_fasta_header
     )
-    print('cov_out')
+    print("cov_out")
     print(cov_out_df.shape)
     print(cov_out_df.head())
     print()
-    print('percent cvg')
+    print("percent cvg")
     print(percent_cvg_df.shape)
     print(percent_cvg_df.head())
     print()
     print(nextclade_df.shape)
-    print('nextclade')
+    print("nextclade")
     print()
-    
 
     # g_clade is being phased out and sometimes is not present in the nextclade output
-    print('----------------filter columns in nextclade to sample name and clade')
+    print("----------------filter columns in nextclade to sample name and clade")
     nextclade_df = nextclade_df[["sample_name", "clade"]]
     nextclade_df = nextclade_df.set_index("sample_name")
     print(nextclade_df.head())
 
-
     # join
-    print('-------------------------joinin all dfs')
+    print("-------------------------joinin all dfs")
     j = df.join(workbook, how="left")
-    print('first join base df and wb')
+    print("first join base df and wb")
     print(j.shape)
     print(j.head())
     print()
-    print('-----------------------')
+    print("-----------------------")
     j = j.join(percent_cvg_df, how="left")
-    print('second join with percent cvg df')
+    print("second join with percent cvg df")
     print(j.shape)
     print(j.head())
     print()
-    print('--------------------')
+    print("--------------------")
     j = j.join(cov_out_df, how="left")
-    print('third join with cov out df')
+    print("third join with cov out df")
     print(j.shape)
     print(j.head())
     print()
     j = j.join(nextclade_df, how="left")
-    print('fourth join with nextclade df')
+    print("fourth join with nextclade df")
     print(j.shape)
     print(j.head())
     print()
     j = j.reset_index()
 
     # add fasta header
-    print('-------------------------adding fasta header')
+    print("-------------------------adding fasta header")
     j["fasta_header"] = j.apply(lambda x: create_fasta_header(x.sample_name), axis=1)
     print(j.shape)
     print(j.head())
 
     # add assembled column and fill in failed assembles with 0% coveage
-    print('------------------------adding assembly pass column and filling in missing percent coverage')
+    print(
+        "------------------------adding assembly pass column and filling in missing percent coverage"
+    )
     j.percent_coverage = j.percent_coverage.fillna(value=0)
 
     def get_assembly_pass(percent_coverage: float) -> bool:
@@ -306,10 +304,10 @@ def concat_results(
 
     print(j.shape)
     print(j.head())
-    print('')
+    print("")
 
     # order columns
-    print('--------------------------------ordering columns')
+    print("--------------------------------ordering columns")
     columns = j.columns.tolist()
     columns.sort()
     primary_columns = [
@@ -322,7 +320,7 @@ def concat_results(
         "run_name",
         "run_date",
         "percent_coverage",
-        "clade"
+        "clade",
     ]
     for column in columns:
         if column not in primary_columns:
@@ -333,22 +331,22 @@ def concat_results(
     print(j.head())
     print()
 
-    print('---------------------------writing to csv')
+    print("---------------------------writing to csv")
     outfile = "%s_sequencing_results.csv" % project_name
     j.to_csv(outfile, index=False)
-    print('----------------------END concat_results-------------')
-    print('')
+    print("----------------------END concat_results-------------")
+    print("")
 
     return j
 
 
 def main(args: argparse.Namespace) -> None:
     """Main function."""
-    print('------------------BEGIN main-------------')
+    print("------------------BEGIN main-------------")
     setup_logging(log_level=args.log_level)
     log.info("Sequencing results start.")
 
-    print('------------------gathering args-------------')
+    print("------------------gathering args-------------")
 
     sample_name_array = args.sample_name_array
     workbook_path = args.workbook_path
@@ -358,7 +356,7 @@ def main(args: argparse.Namespace) -> None:
     assembler_version = args.assembler_version
     project_name = args.project_name
 
-    print('------------------creating lists from inputs-------------')
+    print("------------------creating lists from inputs-------------")
     # create lists from the column table txt file input
     sample_name_list = create_list_from_write_lines_input(
         write_lines_input=sample_name_array
@@ -373,7 +371,7 @@ def main(args: argparse.Namespace) -> None:
         write_lines_input=nextclade_csv_files
     )
 
-    print('------------------concatenating input files-------------')
+    print("------------------concatenating input files-------------")
 
     # concat cov_out files, percent_cvg files, and nextclade files
     cov_out_df = concat_cov_out(cov_out_file_list=cov_out_file_list)
@@ -393,7 +391,7 @@ def main(args: argparse.Namespace) -> None:
 
     log.info("Sequencing results summary end.")
 
-    print('------------------END main-------------')
+    print("------------------END main-------------")
 
 
 if __name__ == "__main__":

--- a/scripts/concat_seq_results.py
+++ b/scripts/concat_seq_results.py
@@ -288,7 +288,7 @@ def concat_results(
     print(
         "------------------------adding assembly pass column and filling in missing percent coverage"
     )
-    j.percent_coverage = j.percent_coverage.fillna(value=0)
+    j["percent_coverage"] = j.percent_coverage.fillna(value=0)
 
     def get_assembly_pass(percent_coverage: float) -> bool:
         if percent_coverage > 0:

--- a/scripts/concat_seq_results.py
+++ b/scripts/concat_seq_results.py
@@ -81,6 +81,9 @@ def create_list_from_write_lines_input(write_lines_input: str) -> list[str]:
 def concat_cov_out(cov_out_file_list: list[str]) -> pd.DataFrame:
     """Concatenate covergate output files."""
     # initiate dataframe for concatenation
+    print('------------------BEGIN concat_cov_out -------------')
+    print('concatenating cov out files')
+    print(f'length of cov out files: {len(cov_out_file_list)}')
     df = pd.DataFrame()
     sample_name_list = []
     samtools_mapped_reads_list = []
@@ -116,29 +119,71 @@ def concat_cov_out(cov_out_file_list: list[str]) -> pd.DataFrame:
     df["mean_base_quality"] = samtools_baseq_list
     df["mean_map_quality"] = samtools_mapq_list
 
+    print(f'cov out concatenated size: {df.shape}')
+    print()
+    print(df.head)
+    print()
+    print(f'# row with NAs: {df[df.isna().any(axis=1)].shape}')
+    print(df[df.isna().any(axis=1)])
+    print('')
+    print('---------------END cov out ---------------')   
+    print('')
+
     return df
 
 
 def concat_percent_cvg(percent_cvg_file_list: list[str]) -> pd.DataFrame:
     """Concatenate percent coverage files."""
+    print('------------------BEGIN concat_percent_cvg-------------')
+    print('concatenating percent cvg files files')
+    print(f'length of cov out files: {len(percent_cvg_file_list)}')
+
     df_list = []
     for file in percent_cvg_file_list:
         d = pd.read_csv(file, dtype={"sample_name": object})
         df_list.append(d)
 
+    print(f'number of dataframes to concat in list: {len(df_list)}')
+
     df = pd.concat(df_list)
+
+    print(f'percent cvg concatenated size: {df.shape}')
+    print()
+    print(df.head())
+    print()
+    print(f'# row with NAs: {df[df.isna().any(axis=1)].shape}')
+    print(df[df.isna().any(axis=1)])
+    print('')
+    print('---------------END perecent coverage out---------------')   
+    print('')
 
     return df
 
 
 def concat_nextclade_csv(nextclade_csv_file_list: list[str]) -> pd.DataFrame:
     """Concatenate nextclade csv files."""
+    print('------------------BEGIN concat nextclade-------------')
+    print('concatenating nextclade files')
+    print(f'length of cov out files: {len(nextclade_csv_file_list)}')
     df_list = []
     for file in nextclade_csv_file_list:
         d = pd.read_csv(file, sep=";")
         df_list.append(d)
-
+    
+    print(f'number of dataframes to concat in list: {len(df_list)}')
     df = pd.concat(df_list)
+
+
+    print(f'nextclade concatenated size: {df.shape}')
+    print()
+    print(df.head())
+    print()
+    print(f'# row with NAs: {df[df.isna().any(axis=1)].shape}')
+    print(df[df.isna().any(axis=1)])
+    print('')
+    print('---------------END nextclade ---------------')   
+    print('')
+
     return df
 
 
@@ -152,6 +197,7 @@ def concat_results(
     nextclade_df: pd.DataFrame,
 ) -> pd.DataFrame:
     """Concatenate results."""
+    print('------------------BEGIN concat_results-------------')
 
     # set some functions for getting data formatted
     def get_sample_name_from_fasta_header(fasta_header: str) -> str:
@@ -162,42 +208,88 @@ def concat_results(
         return "CO-CDPHE-%s" % sample_name
 
     # create dataframe and fill with constant strings
+    print('----------------creating base df')
     df = pd.DataFrame()
     df["sample_name"] = sample_name_list
     df = df.set_index("sample_name")
     df["analysis_date"] = str(date.today())
     df["assembler_version"] = assembler_version
+    print(df.shape)
+    print(df.head())
 
     # read in workbook
+    print('')
+    print('-----------------reading in wb')
     workbook = pd.read_csv(
         workbook_path, sep="\t", dtype={"sample_name": object, "hsn": object}
     )
     workbook = workbook.set_index("sample_name")
+    print(workbook.shape)
+    print(workbook.head)
+    print('')
+
 
     # set index on the samtools_df and percent_cvg_df and variants_df to prepare for joining
+    print('----------------setting index on dfs before merging')
     cov_out_df = cov_out_df.set_index("sample_name")
     percent_cvg_df = percent_cvg_df.set_index("sample_name")
     nextclade_df["sample_name"] = nextclade_df["seqName"].apply(
         get_sample_name_from_fasta_header
     )
+    print('cov_out')
+    print(cov_out_df.shape)
+    print(cov_out_df.head())
+    print()
+    print('percent cvg')
+    print(percent_cvg_df.shape)
+    print(percent_cvg_df.head())
+    print()
+    print(nextclade_df.shape)
+    print('nextclade')
+    print()
+    
 
     # g_clade is being phased out and sometimes is not present in the nextclade output
-    if "G_clade" not in nextclade_df.columns:
-        nextclade_df["G_clade"] = None
-    nextclade_df = nextclade_df[["sample_name", "clade", "G_clade"]]
+    print('----------------filter columns in nextclade to sample name and clade')
+    nextclade_df = nextclade_df[["sample_name", "clade"]]
     nextclade_df = nextclade_df.set_index("sample_name")
+    print(nextclade_df.head())
+
 
     # join
+    print('-------------------------joinin all dfs')
     j = df.join(workbook, how="left")
+    print('first join base df and wb')
+    print(j.shape)
+    print(j.head())
+    print()
+    print('-----------------------')
     j = j.join(percent_cvg_df, how="left")
+    print('second join with percent cvg df')
+    print(j.shape)
+    print(j.head())
+    print()
+    print('--------------------')
     j = j.join(cov_out_df, how="left")
+    print('third join with cov out df')
+    print(j.shape)
+    print(j.head())
+    print()
     j = j.join(nextclade_df, how="left")
+    print('fourth join with nextclade df')
+    print(j.shape)
+    print(j.head())
+    print()
     j = j.reset_index()
 
     # add fasta header
+    print('-------------------------adding fasta header')
     j["fasta_header"] = j.apply(lambda x: create_fasta_header(x.sample_name), axis=1)
+    print(j.shape)
+    print(j.head())
 
     # add assembled column and fill in failed assembles with 0% coveage
+    print('------------------------adding assembly pass column and filling in missing percent coverage')
     j.percent_coverage = j.percent_coverage.fillna(value=0)
 
     def get_assembly_pass(percent_coverage: float) -> bool:
@@ -212,7 +304,12 @@ def concat_results(
         lambda x: get_assembly_pass(x.percent_coverage), axis=1
     )
 
+    print(j.shape)
+    print(j.head())
+    print('')
+
     # order columns
+    print('--------------------------------ordering columns')
     columns = j.columns.tolist()
     columns.sort()
     primary_columns = [
@@ -225,25 +322,33 @@ def concat_results(
         "run_name",
         "run_date",
         "percent_coverage",
-        "clade",
-        "G_clade",
+        "clade"
     ]
     for column in columns:
         if column not in primary_columns:
             primary_columns.append(column)
 
     j = j[primary_columns]
+    print(j.shape)
+    print(j.head())
+    print()
 
+    print('---------------------------writing to csv')
     outfile = "%s_sequencing_results.csv" % project_name
     j.to_csv(outfile, index=False)
+    print('----------------------END concat_results-------------')
+    print('')
 
     return j
 
 
 def main(args: argparse.Namespace) -> None:
     """Main function."""
+    print('------------------BEGIN main-------------')
     setup_logging(log_level=args.log_level)
     log.info("Sequencing results start.")
+
+    print('------------------gathering args-------------')
 
     sample_name_array = args.sample_name_array
     workbook_path = args.workbook_path
@@ -253,6 +358,7 @@ def main(args: argparse.Namespace) -> None:
     assembler_version = args.assembler_version
     project_name = args.project_name
 
+    print('------------------creating lists from inputs-------------')
     # create lists from the column table txt file input
     sample_name_list = create_list_from_write_lines_input(
         write_lines_input=sample_name_array
@@ -266,6 +372,8 @@ def main(args: argparse.Namespace) -> None:
     nextclade_csv_file_list = create_list_from_write_lines_input(
         write_lines_input=nextclade_csv_files
     )
+
+    print('------------------concatenating input files-------------')
 
     # concat cov_out files, percent_cvg files, and nextclade files
     cov_out_df = concat_cov_out(cov_out_file_list=cov_out_file_list)
@@ -284,6 +392,8 @@ def main(args: argparse.Namespace) -> None:
     )
 
     log.info("Sequencing results summary end.")
+
+    print('------------------END main-------------')
 
 
 if __name__ == "__main__":

--- a/tasks/post_assembly_tasks.wdl
+++ b/tasks/post_assembly_tasks.wdl
@@ -17,7 +17,7 @@ task calc_bam_stats_samtools {
         samtools stats ~{bam} > ~{sample_name}_stats.txt
         samtools coverage -m -o ~{sample_name}_coverage_hist.txt ~{bam}
         samtools coverage -o ~{sample_name}_coverage.txt ~{bam}
-        samtools depth -o {sample_name}_depth.txt -a -J {bam}
+        samtools depth -o ~{sample_name}_depth.txt -a -J ~{bam}
     >>>
 
     output {

--- a/tasks/post_assembly_tasks.wdl
+++ b/tasks/post_assembly_tasks.wdl
@@ -17,6 +17,7 @@ task calc_bam_stats_samtools {
         samtools stats ~{bam} > ~{sample_name}_stats.txt
         samtools coverage -m -o ~{sample_name}_coverage_hist.txt ~{bam}
         samtools coverage -o ~{sample_name}_coverage.txt ~{bam}
+        samtools depth -o {sample_name}_depth.txt -a -J {bam}
     >>>
 
     output {
@@ -30,6 +31,7 @@ task calc_bam_stats_samtools {
         File stats_out = "${sample_name}_stats.txt"
         File covhist_out = "${sample_name}_coverage_hist.txt"
         File cov_out = "${sample_name}_coverage.txt"
+        File depth_out = "${sample_name}_depth.txt"
     }
 
     runtime {

--- a/tasks/post_assembly_tasks.wdl
+++ b/tasks/post_assembly_tasks.wdl
@@ -157,6 +157,7 @@ task transfer_outputs {
         File stats_out
         File covhist_out
         File cov_out
+        File stats_depth_out
 
         File renamed_consensus
         File version_capture_file
@@ -185,6 +186,7 @@ task transfer_outputs {
         gsutil -m cp ~{stats_out} ~{out_dir_path}/bam_stats/
         gsutil -m cp ~{covhist_out} ~{out_dir_path}/bam_stats/
         gsutil -m cp ~{cov_out} ~{out_dir_path}/bam_stats/
+        gsutil -m cp ~{stats_depth_out} ~{out_dir_path}/bam_stats/
                        
         gsutil -m cp ~{renamed_consensus} ~{out_dir_path}/assemblies/
         gsutil -m cp ~{version_capture_file} ~{out_dir_path}/summary_results/

--- a/tasks/summary_tasks.wdl
+++ b/tasks/summary_tasks.wdl
@@ -48,7 +48,6 @@ task summarize_results {
 
     output {
         File sequencing_results_csv = "~{project_name}_sequencing_results.csv"
-        File wgs_horizon_report_csv = "~{project_name}_wgs_horizon_report.csv"
     }
 
     runtime {
@@ -64,7 +63,6 @@ task transfer_outputs {
         String out_dir
         File cat_fastas
         File sequencing_results_csv
-        File wgs_horizon_report_csv
     }
 
     String outdirpath = sub(out_dir, "/$", "")
@@ -72,7 +70,6 @@ task transfer_outputs {
     command <<<
         gsutil -m cp ~{cat_fastas} ~{outdirpath}/multifasta/
         gsutil -m cp ~{sequencing_results_csv} ~{outdirpath}/summary_results/
-        gsutil -m cp ~{wgs_horizon_report_csv} ~{outdirpath}/summary_results/
     >>>
 
     runtime {

--- a/workflows/RSV_illumina_pe_assembly.wdl
+++ b/workflows/RSV_illumina_pe_assembly.wdl
@@ -157,6 +157,7 @@ workflow RSV_illumina_pe_assembly {
             consensus = call_consensus.consensus_out,
             flagstat_out = calc_bam_stats.flagstat_out,
             stats_out = calc_bam_stats.stats_out,
+            stats_depth_out = calc_bam_stats.depth_out,
             covhist_out = calc_bam_stats.covhist_out,
             cov_out = calc_bam_stats.cov_out,
             renamed_consensus = rename_fasta.renamed_consensus,

--- a/workflows/RSV_illumina_pe_assembly.wdl
+++ b/workflows/RSV_illumina_pe_assembly.wdl
@@ -191,6 +191,7 @@ workflow RSV_illumina_pe_assembly {
         File stats_out = calc_bam_stats.stats_out
         File covhist_out = calc_bam_stats.covhist_out
         File cov_out = calc_bam_stats.cov_out
+        File depth_out = calc_bam_stats.depth_out
 
         File renamed_consensus = rename_fasta.renamed_consensus
 

--- a/workflows/RSV_illumina_pe_summary.wdl
+++ b/workflows/RSV_illumina_pe_summary.wdl
@@ -49,8 +49,7 @@ workflow RSV_illumina_pe_summary {
         input:
             out_dir = "~{out_dir_path}/~{workflow_version_capture.workflow_version_path}",
             cat_fastas = concatenate_consensus.cat_fastas,
-            sequencing_results_csv = summarize_results.sequencing_results_csv,
-            wgs_horizon_report_csv = summarize_results.wgs_horizon_report_csv
+            sequencing_results_csv = summarize_results.sequencing_results_csv
     }
 
     output {
@@ -59,6 +58,5 @@ workflow RSV_illumina_pe_summary {
         File cat_fastas = concatenate_consensus.cat_fastas
 
         File sequencing_results_csv = summarize_results.sequencing_results_csv
-        File wgs_horizon_report_csv = summarize_results.wgs_horizon_report_csv
     }
 }


### PR DESCRIPTION
This PR

closes #34 - samtools depth

closes #23 - remove gclade

closes #18 - remove horizon report

Testing 🛠️
Test dataset(s):
test_tiled_idp_0005_nextseq. The workflow completed successfully. The samtools depth file was created. The concat seq results did not create the horizon report and the summary file did not contain the g clade column.
